### PR TITLE
Remove -unsupported-allow-new-glibc

### DIFF
--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -14,7 +14,7 @@ class QtWidgetsApplicationTestConan(ConanFile):
 
     def test(self):
         executable = os.path.join(self.build_folder, "QtWidgetsApplication")
-        self.run("linuxdeployqt %s -unsupported-allow-new-glibc" % executable, run_environment=True)
+        self.run("linuxdeployqt %s" % executable, run_environment=True)
         # Avoid running test executable on machines which haven't displays.
         #self.run(executable)
         return


### PR DESCRIPTION
That option is undocumented, unsupported and not recommended. Doing so would result in AppImages that will not run on all still-supported Linux distributions, and will not pass verification.

References:
* https://docs.appimage.org/introduction/concepts.html#build-on-old-systems-run-on-newer-systems
* https://github.com/probonopd/linuxdeployqt/issues/340